### PR TITLE
Fix state updates for available items in TripDetails

### DIFF
--- a/src/components/TripDetails.tsx
+++ b/src/components/TripDetails.tsx
@@ -87,7 +87,7 @@ export default function TripDetails({ trip, onTripUpdate }: TripDetailsProps) {
       const updatedTrip = addItemToBag(trip.id, bagId, item);
       if (updatedTrip) {
         onTripUpdate(updatedTrip);
-        setAvailableItems(availableItems.filter(i => i.id !== item.id));
+        setAvailableItems(prev => prev.filter(i => i.id !== item.id));
       }
     } catch (error) {
       console.error('Error adding item to bag:', error);
@@ -101,7 +101,7 @@ export default function TripDetails({ trip, onTripUpdate }: TripDetailsProps) {
       onTripUpdate(updatedTrip);
       const item = getAllClothingItems().find(i => i.id === itemId);
       if (item) {
-        setAvailableItems([...availableItems, item]);
+        setAvailableItems(prev => [...prev, item]);
       }
     }
   };


### PR DESCRIPTION
## Summary
- avoid stale closures when modifying available items

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68420403f7748324bdea0445054697ba